### PR TITLE
Fix domain WHOIS lookup on Python 3.11

### DIFF
--- a/ftm/analyze.py
+++ b/ftm/analyze.py
@@ -23,7 +23,7 @@ c) Exportar um relatório em PDF.
 """
 import socket
 import texttable as tt
-import pythonwhois
+import json
 import re
 import urllib.request
 from bs4 import BeautifulSoup
@@ -108,16 +108,14 @@ def findservidor(dominio_analisado, dicsubdominios):
 
 
 def d_whois(dominio_analisado):
-    rawwhois = []
+    """Retorna informações de WHOIS através do serviço RDAP."""
+    url = f"https://rdap.org/domain/{dominio_analisado}"
     try:
-        whois = pythonwhois.get_whois(dominio_analisado)
-        rawwhois = whois.get('raw')
-    except UnicodeDecodeError:
-        # rawwhois = ['Erro na coleta de dados do domínio. Tente https://registro.br/cgi-bin/whois/']
-        rawwhois.append(os.popen('~/vendor/whois/usr/bin/whois %s' % dominio_analisado).read())
-        # rawwhois.append(requests.get ("https://registro.br/cgi-bin/whois/?qr=%s" % dominio_analisado).text)
-        pass
-    return (rawwhois[0])
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = resp.read().decode("utf-8")
+        return data
+    except Exception:
+        return "Erro na coleta de dados do domínio via RDAP."
 
 
 def ip_whois(dicsubdominios):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ dnspython==1.15.0
 dnspython3==1.15.0
 ipwhois==0.14.0
 ntplib==0.3.3
-pythonwhois==2.4.3
 six==1.10.0
 texttable==0.8.4
 validators==0.11.0


### PR DESCRIPTION
## Summary
- drop `pythonwhois` dependency that fails on Python 3.11
- query RDAP service over HTTPS instead of using `pythonwhois`

## Testing
- `python -m py_compile ftm/analyze.py`
- *(failed)* `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684061c126b8832cb48368a9ba1b55f0